### PR TITLE
[機能開発]RegQueryValueExWをRegGetValueWに変更する #46

### DIFF
--- a/workspace-rust/config-creater/build.rs
+++ b/workspace-rust/config-creater/build.rs
@@ -37,7 +37,10 @@ fn main() {
     println!(
         "cargo:rustc-env=VERSION_INFO={}",
         [
-            format!("ConfigCreater.exe {}", std::env::var("VERSION").unwrap_or(env!("CARGO_PKG_VERSION").to_string())),
+            format!(
+                "ConfigCreater.exe {}",
+                std::env::var("VERSION").unwrap_or(env!("CARGO_PKG_VERSION").to_string())
+            ),
             format!("rustc {}", rustc_version),
             format!("{}", metadata_dependencies)
         ]

--- a/workspace-rust/wallpaper-changer/build.rs
+++ b/workspace-rust/wallpaper-changer/build.rs
@@ -37,7 +37,10 @@ fn main() {
     println!(
         "cargo:rustc-env=VERSION_INFO={}",
         [
-            format!("WallpaperChanger.exe {}", std::env::var("VERSION").unwrap_or(env!("CARGO_PKG_VERSION").to_string())),
+            format!(
+                "WallpaperChanger.exe {}",
+                std::env::var("VERSION").unwrap_or(env!("CARGO_PKG_VERSION").to_string())
+            ),
             format!("rustc {}", rustc_version),
             format!("{}", metadata_dependencies)
         ]

--- a/workspace-rust/wallpaper-registry/build.rs
+++ b/workspace-rust/wallpaper-registry/build.rs
@@ -37,7 +37,10 @@ fn main() {
     println!(
         "cargo:rustc-env=VERSION_INFO={}",
         [
-            format!("WallpaperRegistry.exe {}", std::env::var("VERSION").unwrap_or(env!("CARGO_PKG_VERSION").to_string())),
+            format!(
+                "WallpaperRegistry.exe {}",
+                std::env::var("VERSION").unwrap_or(env!("CARGO_PKG_VERSION").to_string())
+            ),
             format!("rustc {}", rustc_version),
             format!("{}", metadata_dependencies)
         ]


### PR DESCRIPTION
change: RustのWallpaperChangerでレジストリ情報を取得する時にRegGetValueWを使用するように変更
formatter: フォーマッター適用